### PR TITLE
fix: add port variable in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ npm install
 Run the following command and navigate to [http://localhost:3000](http://localhost:3000).
 
 ```bash
-npm run dev
+PORT=3000 npm run dev
 ```


### PR DESCRIPTION
By default remix run on a different port each execution which renders the setup instructions useless.